### PR TITLE
issues/284_404_Not_found - Added @ApiResponse annotation for NOT_FOUN…

### DIFF
--- a/core/src/main/java/greencity/controller/UserController.java
+++ b/core/src/main/java/greencity/controller/UserController.java
@@ -371,6 +371,7 @@ public class UserController {
         @ApiResponse(responseCode = "200", description = HttpStatuses.OK),
         @ApiResponse(responseCode = "400", description = HttpStatuses.BAD_REQUEST),
         @ApiResponse(responseCode = "401", description = HttpStatuses.UNAUTHORIZED),
+        @ApiResponse(responseCode = "404", description = HttpStatuses.NOT_FOUND)
     })
     @GetMapping("isOnline/{userId}/")
     public ResponseEntity<Boolean> checkIfTheUserIsOnline(


### PR DESCRIPTION
Environment: Firefox 116.0.3 (64-bit).
Reproducible: always.

Preconditions
Sign-in us Admin
Moved to Swagger http://localhost:8065/swagger-ui.html#/

Steps to reproduce

Click on User controller
Click on GET /user/isOnline/{userId}/
Click on 'Try out'
Enter invalid params - (example) userId - 456
Actual result
Response 401 Unauthorized

Expected result
Response 404 Not found

